### PR TITLE
fix(ui): top action sizing for sidebar + minor UI adjustments here and there

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * UI: change the popup header background from a dark color to a much lighter one, to keep a more consistent light-theme look.
-* UI: fix the popup top-action height when the addon is used in sidebar mode, it was way too small
+* UI: fix the popup top-action height when the addon is used in sidebar mode, it was way too small and is now more consistent with the regular popup.
 
 
 ## 0.12.24 and 0.12.25 - November 2024

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * UI: change the popup header background from a dark color to a much lighter one, to keep a more consistent light-theme look.
+* UI: fix the popup top-action height when the addon is used in sidebar mode, it was way too small
 
 
 ## 0.12.24 and 0.12.25 - November 2024

--- a/src/assets/shared.css
+++ b/src/assets/shared.css
@@ -1,7 +1,4 @@
 :root {
-  --top-actions-height: 2.2rem;
-  --top-actions-y-padding: 0.4rem;
-
   --background: #fcfcfc;
   --background-darker: #d2d3db;
   --pocket-aqua: #50bcb6;

--- a/src/options/options.css
+++ b/src/options/options.css
@@ -45,9 +45,11 @@ h2 {
   &.notice {
     padding: 0.5rem 1rem;
     margin: 1rem 0rem;
-    color: #444;
-    border-radius: 4px;
-    background-color: #bae1f2;
+
+    color: var(--ff-primary-text);
+    line-height: 1.4;
+    border-radius: 6px;
+    background-color: #d8ecf6;
   }
 
   label {

--- a/src/options/options.css
+++ b/src/options/options.css
@@ -12,19 +12,22 @@ body {
 
 .saved-notification {
   position: absolute;
+
+  /* Starting position: the top value is then updated via JS
+   * to move the save notification to the correct row */
   right: 0;
   top: 1rem;
 
-  width: 100px;
-  padding: 2px;
+  margin-top: 0.2rem;
+  padding: 0.2rem 1rem;
 
-  background-color: rgba(var(--ff-green-60), 0.2);
+  background-color: rgba(var(--ff-green-60-rgb), 0.1);
   color: var(--ff-green-60);
   font-weight: bold;
   text-align: center;
 
   border: 2px solid var(--ff-green-60);
-  border-radius: 2px;
+  border-radius: 4px;
 
   opacity: 1;
   transition: opacity 400ms ease-out;
@@ -39,8 +42,8 @@ h2 {
 .row {
   margin: 0px;
   padding: 6px 0px 6px 6px;
-  line-height: 16px;
-  border-top: 1px solid #e1e1e1;
+  line-height: 1.2;
+  border-top: 1px solid var(--ff-grey-20);
 
   &.notice {
     padding: 0.5rem 1rem;

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -42,10 +42,13 @@ const UI = (function () {
     savedNotificationElement.classList.remove("hidden")
 
     if (containerRow) {
-      const topMarginInPx = 2
+      const containerHeight = containerRow.offsetHeight
+      const notificationHeight = savedNotificationElement.offsetHeight
+      const topMarginInPx = Math.floor((containerHeight - notificationHeight) / 2)
       const offsetTop = parseInt(containerRow.offsetTop, parseIntBase) + topMarginInPx
       savedNotificationElement.style.top = `${offsetTop}px`
     } else {
+      // Move it all the way back to the top of the settings UI
       savedNotificationElement.style.top = "0px"
     }
 

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -56,13 +56,13 @@ body {
   align-items: center;
 
   button {
-    margin: 2rem;
+    margin: 3rem;
     padding: 1rem 2rem;
     background-color: var(--ff-blue-50);
-    border: 1px solid;
-    border-radius: 4px;
+    border-width: 0px;
+    border-radius: 8px;
     color: white;
-    font-size: 1.4rem;
+    font-size: 1.5rem;
     cursor: pointer;
 
     max-width: 80%;

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -4,9 +4,10 @@
   display: none !important;
 }
 
+/* TODO: remove actions-y-padding if not needed anymore */
 :root {
-  --top-actions-height: 2.2rem;
-  --top-actions-y-padding: 0.4rem;
+  --top-actions-height: 3rem;
+  --top-actions-y-padding: 1.5rem;
 }
 
 html {
@@ -442,9 +443,11 @@ body {
   display: flex;
   flex-direction: row;
   align-items: center;
+  gap: 0.8rem;
 
-  height: var(--top-actions-height);
-  padding: var(--top-actions-y-padding) 0;
+  min-height: var(--top-actions-height);
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
 
   background-color: var(--background-darker);
   color: var(--ff-grey-70);
@@ -455,18 +458,10 @@ body {
     cursor: pointer;
     font-size: 1.9rem;
 
-    width: 2rem;
-    margin-right: 0.4rem;
-
-    &:first-child {
-      margin-left: 0.4rem;
-    }
-
     &.random-item {
       font-weight: bold;
     }
 
-    /* This icon is separated from the other "item lists" action hence a large right margin */
     &.filter-faved {
       position: relative;
 
@@ -509,30 +504,27 @@ body {
   .filter-items-container {
     position: relative;
     flex: 1;
-    margin-right: 2rem;
+    margin-left: 1rem;
+    margin-right: 1rem;
 
     .clear-search-box {
       position: absolute;
-      top: -0.2rem;
-      right: -1rem;
+      top: -0.35rem;
+      right: 0.15rem;
       color: var(--ff-grey-40);
       font-size: 2.2rem;
       cursor: pointer;
     }
 
     .filter-items {
+      box-sizing: border-box;
       width: 100%;
       padding: 0.3rem 0.6rem;
-      height: 1.6rem;
 
       background-color: rgba(255, 255, 255, 0.7);
       border-radius: 1rem;
       border: 0px transparent;
-      font-size: 1.1rem;
-
-      &:focus {
-        outline: none;
-      }
+      font-size: 1.15rem;
     }
   }
 }
@@ -566,6 +558,7 @@ body {
   z-index: 3;
   display: block !important;
   position: absolute;
+  /* TODO: check if this is still positionned correctly */
   top: calc(var(--top-actions-height) + 2 * var(--top-actions-y-padding));
   width: 100%;
   opacity: 1;

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -4,10 +4,8 @@
   display: none !important;
 }
 
-/* TODO: remove actions-y-padding if not needed anymore */
 :root {
   --top-actions-height: 3rem;
-  --top-actions-y-padding: 1.5rem;
 }
 
 html {
@@ -445,7 +443,7 @@ body {
   align-items: center;
   gap: 0.8rem;
 
-  min-height: var(--top-actions-height);
+  height: var(--top-actions-height);
   padding-left: 0.5rem;
   padding-right: 0.5rem;
 
@@ -553,14 +551,13 @@ body {
 }
 
 .flash-overlay {
-  flex: initial;
+  /* Needed to counter the 'display:none' of the .hidden class. Without this, the overlay
+  * display goes from block to none, and is hidden all at once */
+  display: block !important;
 
   z-index: 3;
-  display: block !important;
   position: absolute;
-  /* TODO: check if this is still positionned correctly */
-  top: calc(var(--top-actions-height) + 2 * var(--top-actions-y-padding));
-  width: 100%;
+  top: var(--top-actions-height);
   opacity: 1;
   transition: height 200ms ease-out, opacity 200ms ease-out;
 
@@ -592,7 +589,7 @@ body {
     opacity: 0;
     transition: height 250ms ease-out, opacity 0 250ms ease-out;
 
-    /* Let's make sure the item really takes no space in the popup, or it will
+    /* Ensure the item really takes no space in the popup, or it will
      * prevent clicking on the first item of the list */
     padding: 0px;
     line-height: 0;

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -88,7 +88,7 @@ function onError(eventData: RuntimeEvent) {
   }
 
   // Show flash message + flash the badge if an error occured
-  PopupFlash.show(flashMessage, FlashKind.ERROR, 5000)
+  PopupFlash.show(flashMessage, FlashKind.ERROR, 6000)
   browser.runtime.sendMessage({ action: "flash-error" })
 
   // TODO: BugReporter is already called from Request. Is this useful at all?


### PR DESCRIPTION
## What?

- fix: improve the top actions bar sizing, especially for sidebar mode where it was way too thin
- ui: turn the top actions bar background to a light grey, in order to prepare for upcoming light/dark themes 
- ui: update auth button, make it bigger and bigger radius